### PR TITLE
fix: fix web-ext import (plugin currently does not work!)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import webext from 'web-ext';
+import * as webext from 'web-ext';
 import {
   Compilation,
   Compiler,


### PR DESCRIPTION
From `web-ext` 5 on, the package export has changed. Although it shouldn't make a difference for the import, it seems to do for TypeScript. This PR fixes the import so the plugin works again.